### PR TITLE
Prevent compilation issue if TMX filename contains spaces.

### DIFF
--- a/bntmx.py
+++ b/bntmx.py
@@ -8,6 +8,7 @@ from tmx import TMX
 import argparse
 import json
 import os
+import re
 import bntemplate
 
 def inline_c_array(l: list) -> str:
@@ -164,7 +165,9 @@ class TMXConverter:
         object_ids = multiline_c_array(self._object_ids_enum(), "    ", 3)
         tileset_bounds = []
         for first, last, tsx in self._tmx.tilesets():
-            enum_base = os.path.splitext(os.path.basename(tsx.filename()))[0].upper()
+            basename = os.path.splitext(os.path.basename(tsx.filename()))[0].upper()
+            # Remove non-alphanumeric characters (e.g. spaces) to prevent compilation errors.
+            enum_base = re.sub(r'[\W_]', '', basename)
             tileset_bounds.append(enum_base + "=" + str(first))
             tileset_bounds.append(enum_base + "_LAST=" + str(last))
         tile_ids = multiline_c_array(tileset_bounds, "    ", 3)


### PR DESCRIPTION
When the TMX filename contains spaces, a cryptic error would occur later during compilation:

```
In file included from build/src/bntmx_maps_examplemap.cpp:1:
build/include/bntmx_maps_examplemap.h:22:25: error: expected '}' before 'DEMO'
```

That's because a TMX with this tileset
```xml
<tileset firstgid="1" source="../assets/Test Tileset.tsx"/>
```

Would compile to this:

```c++
namespace bntmx::maps
{
class examplemap : public map
{
public:
enum object_class {
};


enum object_id {
};


enum tile_id {
TEST TILESET=1,
TEST TILESET_LAST=420
};
```

As a simple solution for this and other invalid characters, I remove all non-alphanumeric characters from the enum keys.