### PR TITLE
Improve error message if file is called map.tmx.

### DIFF
--- a/bntmx.py
+++ b/bntmx.py
@@ -51,6 +51,10 @@ class TMXConverter:
     def __init__(self, tmx_filename):
         self._tmx = TMX(tmx_filename)
         self._name = os.path.splitext(os.path.basename(tmx_filename))[0]
+        if self._name == "map":
+            raise ValueError("Maps cannot be called 'map' because that's the name of the parent class. "
+                             "Please pick a different filename than map.tmx.")
+        
         descriptor = open(os.path.splitext(tmx_filename)[0] + ".json")
         self._descriptor = json.load(descriptor)
 


### PR DESCRIPTION
If the input file is `map.tmx`, a cryptic error is thrown later during compilation:

```
In file included from build/src/bntmx_maps_map.cpp:1:
build/include/bntmx_maps_map.h:10:24: error: invalid use of incomplete type 'class bntmx::maps::map'
   10 |     class map : public map
      |                        ^~~
```

I see no easy fix, so I chose to improve the error message to make it easier to fix for the caller.
