### PR TITLE
Fix tile y coordinate for non-square tilesets.

### DIFF
--- a/tmx.py
+++ b/tmx.py
@@ -170,7 +170,7 @@ class TSX:
         """
 
         src_x = (tile_id % self._columns) * self._tile_width
-        src_y = (tile_id // self._lines) * self._tile_height
+        src_y = (tile_id // self._columns) * self._tile_height
         dst_image.alpha_composite(self._image, (x, y), (src_x, src_y, src_x + self._tile_width, src_y + self._tile_height))
 
 class TMX:


### PR DESCRIPTION
For tilesets that are not square, L173 calculates the wrong tile y coordinate for most tile ids.

https://github.com/Kekun/butano-tiled/blob/1fde1b7522994dd9bf8938258a31d0db35b739c5/tmx.py#L172-L173

I fixed it - we must integer divide by `self._columns` as well.