### PR TITLE
Support palettes with more than 16 colors.

### DIFF
--- a/bntemplate.py
+++ b/bntemplate.py
@@ -135,7 +135,6 @@ public:
 graphics = '''\
 {{
     "type": "regular_bg",
-    "bpp_mode": "bpp_4_auto",
     "height": {bg_height}
 }}
 '''

--- a/bntmx.py
+++ b/bntmx.py
@@ -193,8 +193,15 @@ class TMXConverter:
         for i, layer_path in enumerate(self._descriptor["graphics"]):
             self._tmx.compose(gfx_im, layer_path, 0, bg_height * i)
 
-        # Make the image paletted
-        gfx_im = gfx_im.quantize(256)
+        # Make the image paletted.
+        color_list = gfx_im.getcolors()
+        num_colors = 256
+        if color_list is not None:
+            num_colors = min(256, len(color_list))
+        gfx_im = gfx_im.quantize(num_colors)
+
+        # By default PIL saves with a palette of 256 colors. Reduce to only actually used colors.
+        gfx_im.putpalette(gfx_im.getpalette()[: num_colors * 3])
 
         return gfx_im
 


### PR DESCRIPTION
My map uses more than 16 colors, which fails if bpp_4 is hardcoded. The [docs](https://gvaliente.github.io/butano/import.html#import_bg_palette) state:

> The default is "bpp_4_manual" for 16 color images and "bpp_8" for 256 color images.

So unsetting the value should allow for both.

To allow this, I've implemented a basic palette reduction, which should remove the need to depend on bpp_4_auto.