### PR TITLE
Parse object coordinates more robustly.

### DIFF
--- a/tmx.py
+++ b/tmx.py
@@ -31,9 +31,9 @@ def _object_position(object_node: ET.Element) -> tuple[int,int]:
     # While the origin of maps is their top-left corner, the origin of
     # objects is their bottom left one, hence we have to substract half
     # their height and not add it to get their center.
-    x = int(object_node.get("x")) + int(object_node.get("width")) // 2
-    y = int(object_node.get("y")) - int(object_node.get("height")) // 2
-    return x, y
+    x = float(object_node.get("x")) + float(object_node.get("width", 0)) // 2
+    y = float(object_node.get("y")) + float(object_node.get("height", 0)) // 2
+    return int(x), int(y)
 
 def _objects_layer_path_to_xpath(layer_path: str) -> str:
     """


### PR DESCRIPTION
This includes all changes from #5 and additionally allows reading floating point coordinates, which will be truncated to ints.

From #5: When using Tiled's point object 
<img width="128" alt="image" src="https://github.com/Kekun/butano-tiled/assets/864168/5f3e2887-b7e3-4fd4-b081-6b1b4eaca68e">

An object without width or height is created:
<img width="221" alt="image" src="https://github.com/Kekun/butano-tiled/assets/864168/4cb4db50-5030-4493-9607-3c91e4023aec">

Which fails during compilation:
```
Traceback (most recent call last):
  File "butano-tiled/bntmx.py", line 341, in <module>
    process(args.target, args.mapsdirs, args.build)
  File "butano-tiled/bntmx.py", line 293, in process
    converter = TMXConverter(target, tmx_filename)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "butano-tiled/bntmx.py", line 64, in __init__
    self._objects = list(map(lambda layer_path: self._tmx.objects(layer_path), self._descriptor["objects"]))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "butano-tiled/bntmx.py", line 64, in <lambda>
    self._objects = list(map(lambda layer_path: self._tmx.objects(layer_path), self._descriptor["objects"]))
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "butano-tiled/tmx.py", line 278, in objects
    item_x, item_y = _object_position(item_node)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "butano-tiled/tmx.py", line 35, in _object_position
    x = int(object_node.get("x")) + int(object_node.get("width")) // 2
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

Closes #5